### PR TITLE
Compatibility with redmine 2.6+

### DIFF
--- a/assets/javascripts/redmine_cut_tag.js
+++ b/assets/javascripts/redmine_cut_tag.js
@@ -20,21 +20,12 @@ if (typeof(jQuery) == 'undefined') {
 } else {
   // using jquery
 
-  // compatibility code to use 'live' method on jquery 1.9 (redmine 2.5+)
-  // borrowed from jQuery 1.8.3's source code
-  jQuery.fn.extend({
-    live: function( types, data, fn ) {
-            jQuery( this.context ).on( types, this.selector, data, fn );
-            return this;
-          }
-  });
-
   $(document).ready(function() {
 
     var switchesSelector = '.cut_tag_show,.cut_tag_hide';
     var contentSelector = '.cut_tag_content';
 
-    $(switchesSelector).live('click', function() {
+    $(document).on('click', switchesSelector, function() {
       var selector = switchesSelector + ',' + contentSelector;
       $(this).parent().children(selector).toggle();
       return false;


### PR DESCRIPTION
Plugin compatibility is broken again with redmine 2.6.

Properly migrate from .live to .on as described on http://api.jquery.com/live/ instead of porting a deprecated function.
